### PR TITLE
fix to setup.py to look for numpy headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,13 @@
 
 from distutils.core import setup
 from Cython.Build import cythonize
+import numpy
 
 setup(
     name='box overlaps',
-    ext_modules=cythonize('./utils/box_overlaps.pyx')
+    ext_modules=cythonize('./utils/box_overlaps.pyx'),
+    include_dirs=[numpy.get_include()]
 )
 
 # solution for potential error related to numpy/arrayobject.h
-# export CFLAGS="-I /home/rcf-40/qianguih/.local/lib/python2.7/site-packages/numpy/core/include $CFLAGS"
+#export CFLAGS="-I /home/rcf-40/qianguih/.local/lib/python2.7/site-packages/numpy/core/include $CFLAGS"


### PR DESCRIPTION
Thanks for all your great work @qianguih and  @jeasinema. I found it useful to generalize the setup.py to look for the numpy headers when building the extension. Without this, user might need to manually set where the numpy numpy/arrayobject.h file is, which can be tricky in the virtual env. This should make it more robust. Tested on the University of Florida computing cluster. 

```
(voxelnet) [b.weinstein@dev1 voxelnet]$ python
Python 3.6.5 |Anaconda, Inc.| (default, Mar 29 2018, 18:21:58) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
```

```
(voxelnet) [b.weinstein@dev1 voxelnet]$ python3 setup.py build_ext --inplace
running build_ext
building 'utils.box_overlaps' extension
...
```

Running 

```
(voxelnet) [b.weinstein@dev1 voxelnet]$ cat /proc/version
Linux version 3.10.0-693.17.1.el7.x86_64 (mockbuild@x86-041.build.eng.bos.redhat.com) (gcc version 4.8.5 20150623 (Red Hat 4.8.5-16) (GCC) ) #1 SMP Sun Jan 14 10:36:03 EST 2018
```
inside a conda env.
