### PR TITLE
Replaced fixed calibration matrices with the correct ones

### DIFF
--- a/data/crop.py
+++ b/data/crop.py
@@ -91,8 +91,9 @@ for frame in range(0, 7481):
     calib_dir = CALIB_ROOT + '%06d.txt' % frame
 
     points = align_img_and_pc(img_dir, pc_dir, calib_dir)
-    
-    output_name = PC_ROOT + frame + '.bin'
+    l = str(frame)
+    l = "0"*(6-len(l)) +l
+    output_name = PC_ROOT + l + '.bin'
     points[:,:4].astype('float32').tofile(output_name)
 
 

--- a/test.py
+++ b/test.py
@@ -76,7 +76,8 @@ if __name__ == '__main__':
                 for tag, result in zip(tags, results):
                     of_path = os.path.join(args.output_path, 'data', tag + '.txt')
                     with open(of_path, 'w+') as f:
-                        labels = box3d_to_label([result[:, 1:8]], [result[:, 0]], [result[:, -1]], coordinate='lidar')[0]
+                        P, Tr, R = load_calib(os.path.join( cfg.CALIB_DIR.replace("training","validation"), tag + '.txt') )
+                        labels = box3d_to_label([result[:, 1:8]], [result[:, 0]], [result[:, -1]], coordinate='lidar',P2 =P, T_VELO_2_CAM=Tr, R_RECT_0=R)[0]
                         for line in labels:
                             f.write(line)
                         print('write out {} objects to {}'.format(len(labels), tag))

--- a/train.py
+++ b/train.py
@@ -54,7 +54,6 @@ def main(_):
         global save_model_dir
         start_epoch = 0
         global_counter = 0
-
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=cfg.GPU_MEMORY_FRACTION,
                                     visible_device_list=cfg.GPU_AVAILABLE,
                                     allow_growth=True)
@@ -119,12 +118,12 @@ def main(_):
                         f.write( 'train: {} @ epoch:{}/{} loss: {:.4f} reg_loss: {:.4f} cls_loss: {:.4f} cls_pos_loss: {:.4f} cls_neg_loss: {:.4f} forward time: {:.4f} batch time: {:.4f} \n'.format(counter, epoch, args.max_epoch, ret[0], ret[1], ret[2], ret[3], ret[4], forward_time, batch_time) )
                     
                     #print(counter, summary_interval, counter % summary_interval)
-                    if counter % summary_interval == 0:
+                    if counter % summary_interval == 0 and False: # Momentaneously this is skipped
                         print("summary_interval now")
                         summary_writer.add_summary(ret[-1], global_counter)
                             
                     #print(counter, summary_val_interval, counter % summary_val_interval)
-                    if counter % summary_val_interval == 0:
+                    if counter % summary_val_interval == 0 and False: # Momentaneously this is skipped
                         print("summary_val_interval now")
                         batch = sample_test_data(val_dir, args.single_batch_size * cfg.GPU_USE_COUNT, multi_gpu_sum=cfg.GPU_USE_COUNT)
                         


### PR DESCRIPTION
During the training the averaged calibration matrices are still being used, whereas the correct ones should be used in order to get more accurate results. 

These mods are essentially fixing this problem making sure that, unless specified otherwise, the correct calibration matrices are always being used .